### PR TITLE
Do not cache unversionned keys in CachingKeyResolver

### DIFF
--- a/azure-keyvault-extensions/src/main/java/com/microsoft/azure/keyvault/extensions/CachingKeyResolver.java
+++ b/azure-keyvault-extensions/src/main/java/com/microsoft/azure/keyvault/extensions/CachingKeyResolver.java
@@ -22,6 +22,8 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.microsoft.azure.keyvault.KeyIdentifier;
 import com.microsoft.azure.keyvault.core.IKey;
 import com.microsoft.azure.keyvault.core.IKeyResolver;
 
@@ -30,25 +32,46 @@ import com.microsoft.azure.keyvault.core.IKeyResolver;
  */
 public class CachingKeyResolver implements IKeyResolver {
 
+    private final IKeyResolver keyResolver;
     private final LoadingCache<String, ListenableFuture<IKey>> cache;
-    
+
     /**
      * Constructor.
      * @param capacity the cache size
      * @param keyResolver the key resolver
      */
     public CachingKeyResolver(int capacity, final IKeyResolver keyResolver) {
+        this.keyResolver = keyResolver;
         cache = CacheBuilder.newBuilder().maximumSize(capacity)
                 .build(new CacheLoader<String, ListenableFuture<IKey>>() {
 
                     @Override
                     public ListenableFuture<IKey> load(String kid) {
                         return keyResolver.resolveKeyAsync(kid);
-                    } });
+                    }
+                });
     }
 
     @Override
     public ListenableFuture<IKey> resolveKeyAsync(String kid) {
-        return cache.getUnchecked(kid);
+        KeyIdentifier keyIdentifier = new KeyIdentifier(kid);
+        if (keyIdentifier.version() == null) {
+            final ListenableFuture<IKey> key = keyResolver.resolveKeyAsync(kid);
+            key.addListener(new Runnable() {
+                                @Override
+                                public void run() {
+                                    try {
+                                        cache.put(key.get().getKid(), key);
+                                    } catch (Exception e) {
+                                        // Key caching will occur on first read
+                                    }
+                                }
+                            },
+                    MoreExecutors.directExecutor()
+            );
+            return key;
+        } else {
+            return cache.getUnchecked(kid);
+        }
     }
 }

--- a/azure-keyvault-extensions/src/test/java/com/microsoft/azure/keyvault/extensions/test/CachingKeyResolverTest.java
+++ b/azure-keyvault-extensions/src/test/java/com/microsoft/azure/keyvault/extensions/test/CachingKeyResolverTest.java
@@ -18,27 +18,32 @@
 
 package com.microsoft.azure.keyvault.extensions.test;
 
-import static org.junit.Assert.*;
-
-import org.junit.Test;
-
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.microsoft.azure.keyvault.core.IKey;
 import com.microsoft.azure.keyvault.core.IKeyResolver;
 import com.microsoft.azure.keyvault.extensions.CachingKeyResolver;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.concurrent.Executor;
+
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 public class CachingKeyResolverTest {
-    
+
     @SuppressWarnings("unchecked")
     final ListenableFuture<IKey> ikeyAsync = mock(ListenableFuture.class);
-    final static String keyId = "keyID";
-    final static String keyId2 = "keyID2";
-    final static String keyId3 = "keyID3";
-    
+    final static String keyId = "https://test.vault.azure.net/keys/keyID/version";
+    final static String keyId2 = "https://test.vault.azure.net/keys/keyID2/version";
+    final static String keyId3 = "https://test.vault.azure.net/keys/keyID3/version";
+    final static String newerKeyId3 = "https://test.vault.azure.net/keys/keyID3/version2";
+    final static String unversionnedKeyId3 = "https://test.vault.azure.net/keys/keyID3";
 
-    /* 
+
+    /*
      * Tests the capacity limit of CachingKeyResolver by adding more keys
      * than the cache limit and verifying that least recently used entity is evicted.
      */
@@ -47,51 +52,100 @@ public class CachingKeyResolverTest {
     {
         IKeyResolver mockedKeyResolver = mock(IKeyResolver.class);
         CachingKeyResolver resolver = new CachingKeyResolver(2, mockedKeyResolver);
-        
+
         when(mockedKeyResolver.resolveKeyAsync(keyId)).thenReturn(ikeyAsync);
         when(mockedKeyResolver.resolveKeyAsync(keyId2)).thenReturn(ikeyAsync);
         when(mockedKeyResolver.resolveKeyAsync(keyId3)).thenReturn(ikeyAsync);
-        
+
         resolver.resolveKeyAsync(keyId);
         resolver.resolveKeyAsync(keyId2);
         resolver.resolveKeyAsync(keyId3);
-        
+
         resolver.resolveKeyAsync(keyId2);
         resolver.resolveKeyAsync(keyId3);
         resolver.resolveKeyAsync(keyId);
         resolver.resolveKeyAsync(keyId3);
-        
+
         verify(mockedKeyResolver, times(1)).resolveKeyAsync(keyId2);
         verify(mockedKeyResolver, times(1)).resolveKeyAsync(keyId3);
         verify(mockedKeyResolver, times(2)).resolveKeyAsync(keyId);
     }
-    
-    /* 
-     * Tests the behavior of CachingKeyResolver when resolving key throws 
-     * and validate that the failed entity is not added to the cache. 
+
+    /*
+     * Tests the behavior of CachingKeyResolver when resolving key throws
+     * and validate that the failed entity is not added to the cache.
      */
     @Test
     public void KeyVault_CachingKeyResolverThrows()
     {
         IKeyResolver mockedKeyResolver = mock(IKeyResolver.class);
         CachingKeyResolver resolver = new CachingKeyResolver(10, mockedKeyResolver);
-        
+
         // First throw exception and for the second call return a value
         when(mockedKeyResolver.resolveKeyAsync(keyId))
             .thenThrow(new RuntimeException("test"))
             .thenReturn(ikeyAsync);
-        
+
         try {
             resolver.resolveKeyAsync(keyId);
-            assertFalse("Should have thrown an exception.", true);
+            fail("Should have thrown an exception.");
         }
         catch (UncheckedExecutionException e) {
             assertTrue("RuntimeException is expected.", e.getCause() instanceof RuntimeException);
         }
-        
+
         resolver.resolveKeyAsync(keyId);
         resolver.resolveKeyAsync(keyId);
-        
+
         verify(mockedKeyResolver, times(2)).resolveKeyAsync(keyId);
+    }
+
+    /*
+     * Tests that CachingKeyResolver does not cache unversionned keys,
+     * but does cache the result versionned key
+     */
+    @Test
+    public void KeyVault_CachingUnversionnedKey() throws Exception {
+        IKeyResolver mockedKeyResolver = mock(IKeyResolver.class);
+        CachingKeyResolver resolver = new CachingKeyResolver(2, mockedKeyResolver);
+
+        IKey key = mock(IKey.class);
+
+        when(mockedKeyResolver.resolveKeyAsync(unversionnedKeyId3)).thenReturn(ikeyAsync);
+        when(ikeyAsync.get()).thenReturn(key);
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+                invocationOnMock.getArgumentAt(0, Runnable.class).run();
+                return null;
+            }
+        }).when(ikeyAsync).addListener(any(Runnable.class), any(Executor.class));
+        when(key.getKid()).thenReturn(keyId3);
+
+        /*
+         * First resolve unversionned key
+         */
+        ListenableFuture<IKey> result = resolver.resolveKeyAsync(unversionnedKeyId3);
+        assertEquals(result.get().getKid(), keyId3);
+        verify(mockedKeyResolver, times(1)).resolveKeyAsync(unversionnedKeyId3);
+        verify(mockedKeyResolver, times(0)).resolveKeyAsync(keyId3);
+
+        /*
+         * Second resolve unversionned key, but the result should be a newer key
+         */
+        when(key.getKid()).thenReturn(newerKeyId3);
+        result = resolver.resolveKeyAsync(unversionnedKeyId3);
+        assertEquals(result.get().getKid(), newerKeyId3);
+        verify(mockedKeyResolver, times(2)).resolveKeyAsync(unversionnedKeyId3);
+        verify(mockedKeyResolver, times(0)).resolveKeyAsync(keyId3);
+        verify(mockedKeyResolver, times(0)).resolveKeyAsync(newerKeyId3);
+
+        /*
+         * Check that versionned keys were added to the cache, and do not get resolved again
+         */
+        resolver.resolveKeyAsync(keyId3);
+        resolver.resolveKeyAsync(newerKeyId3);
+        verify(mockedKeyResolver, times(0)).resolveKeyAsync(keyId3);
+        verify(mockedKeyResolver, times(0)).resolveKeyAsync(newerKeyId3);
     }
 }


### PR DESCRIPTION
Fix #6 

When resolving an unversionned key in `CachingKeyResolver`, do not go through the cache directly but always perform an actual `resolveKeyAsync`.

The response key (with version in its key id) is added to the cache once resolved.