### PR TITLE
Update Maven dependency versions to resolve vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <legal><![CDATA[[INFO] Any downloads listed may be third party software.  Microsoft grants you no rights for third party software.]]></legal>
     
     <!-- Version properties -->
-    <jackson.version>2.9.6</jackson.version>
+    <jackson.version>2.9.8</jackson.version>
     
     <!-- Testing properties -->
     <testMode>playback</testMode>
@@ -180,7 +180,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>20.0</version>
+        <version>25.0-jre</version>
       </dependency>
       
       <!-- Test dependencies -->


### PR DESCRIPTION
The older libraries upgraded here bring vulnerabilities with them and should be upgraded.

Component Governance reports highlight them here:
https://dev.azure.com/sqlclientdrivers-ci/mssql-jdbc/_componentGovernance/112445?_a=alerts&typeId=547027&alerts-view-option=active